### PR TITLE
Added compilation support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ if (OPENMP_FOUND)
    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
+# Boost for multiprecision
+# Windows only, Unix has built-in 128bit floating point ops
+IF (WIN32)
+find_package(Boost)
+ENDIF()
+
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 # Eigen
@@ -21,5 +27,13 @@ set(EIGEN_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external)
 file(GLOB sources src/*.cpp)
 add_executable(tthresh ${sources})
 include_directories(${EIGEN_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
+if (WIN32)
+    if (Boost_FOUND)
+        include_directories(${Boost_INCLUDE_DIR})
+        add_definitions(-DHAS_BOOST=1)
+    else()
+        add_definitions(-DHAS_BOOST=0)
+    endif()
+endif()
 target_link_libraries(tthresh ${ZLIB_LIBRARY})
 add_definitions(-std=c++11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,6 @@ if (OPENMP_FOUND)
    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 endif()
 
-# Boost for multiprecision
-# Windows only, Unix has built-in 128bit floating point ops
-IF (WIN32)
-find_package(Boost)
-ENDIF()
-
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 # Eigen
@@ -27,13 +21,5 @@ set(EIGEN_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/external)
 file(GLOB sources src/*.cpp)
 add_executable(tthresh ${sources})
 include_directories(${EIGEN_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
-if (WIN32)
-    if (Boost_FOUND)
-        include_directories(${Boost_INCLUDE_DIR})
-        add_definitions(-DHAS_BOOST=1)
-    else()
-        add_definitions(-DHAS_BOOST=0)
-    endif()
-endif()
 target_link_libraries(tthresh ${ZLIB_LIBRARY})
 add_definitions(-std=c++11)

--- a/src/compress.hpp
+++ b/src/compress.hpp
@@ -116,9 +116,9 @@ vector<uint64_t> encode_array(double* c, size_t size, double eps_target, bool is
 
             if (current_bit) {
                 plane_sse += (LDOUBLE(coreq[i] - current[i]));
-                current[i] |= 1ULL<<q;
+                current[i] |= ((uint64_t)1) << q;
                 if (plane_ones%100 == 0) {
-                    LDOUBLE k = 1ULL<<q;
+                    LDOUBLE k = ((uint64_t)1) << q;
                     LDOUBLE sse_now = sse+(-2*k*plane_sse + k*k*plane_ones);
                     if (sse_now <= thresh) {
                         done = true;
@@ -133,7 +133,7 @@ vector<uint64_t> encode_array(double* c, size_t size, double eps_target, bool is
         if (verbose and is_core)
             cout << endl;
 
-        LDOUBLE k = 1ULL<<q;
+        LDOUBLE k = ((uint64_t)1) << q;
         sse += -2*k*plane_sse + k*k*plane_ones;
         rle.push_back(counter);
 

--- a/src/compress.hpp
+++ b/src/compress.hpp
@@ -14,12 +14,12 @@
 #include "tthresh.hpp"
 #include "tucker.hpp"
 #include "io.hpp"
-#include <unistd.h>
 #include <math.h>
 #include <Eigen/Dense>
 #include <map>
 
 typedef long double LDOUBLE;
+
 
 using namespace std;
 using namespace Eigen;
@@ -116,9 +116,9 @@ vector<uint64_t> encode_array(double* c, size_t size, double eps_target, bool is
 
             if (current_bit) {
                 plane_sse += (LDOUBLE(coreq[i] - current[i]));
-                current[i] |= 1UL<<q;
+                current[i] |= 1ULL<<q;
                 if (plane_ones%100 == 0) {
-                    LDOUBLE k = 1UL<<q;
+                    LDOUBLE k = 1ULL<<q;
                     LDOUBLE sse_now = sse+(-2*k*plane_sse + k*k*plane_ones);
                     if (sse_now <= thresh) {
                         done = true;
@@ -133,7 +133,7 @@ vector<uint64_t> encode_array(double* c, size_t size, double eps_target, bool is
         if (verbose and is_core)
             cout << endl;
 
-        LDOUBLE k = 1UL<<q;
+        LDOUBLE k = 1ULL<<q;
         sse += -2*k*plane_sse + k*k*plane_ones;
         rle.push_back(counter);
 

--- a/src/encode.hpp
+++ b/src/encode.hpp
@@ -42,8 +42,8 @@ THE SOFTWARE.
 using namespace std;
 
 constexpr uint8_t CODE_VALUE_BITS = 32;
-constexpr uint64_t MAX_CODE = (1ULL<<CODE_VALUE_BITS)-1;
-constexpr uint64_t ONE_FOURTH = (MAX_CODE+1ULL)/4;
+constexpr uint64_t MAX_CODE = (((uint64_t)1) << CODE_VALUE_BITS)-1;
+constexpr uint64_t ONE_FOURTH = (MAX_CODE + ((uint64_t)1))/4;
 constexpr uint64_t ONE_HALF = ONE_FOURTH*2;
 constexpr uint64_t THREE_FOURTHS = ONE_FOURTH*3;
 

--- a/src/encode.hpp
+++ b/src/encode.hpp
@@ -41,11 +41,11 @@ THE SOFTWARE.
 
 using namespace std;
 
-uint8_t CODE_VALUE_BITS = 32;
-uint64_t MAX_CODE = (1UL<<CODE_VALUE_BITS)-1;
-uint64_t ONE_FOURTH = (MAX_CODE+1UL)/4;
-uint64_t ONE_HALF = ONE_FOURTH*2;
-uint64_t THREE_FOURTHS = ONE_FOURTH*3;
+constexpr uint8_t CODE_VALUE_BITS = 32;
+constexpr uint64_t MAX_CODE = (1ULL<<CODE_VALUE_BITS)-1;
+constexpr uint64_t ONE_FOURTH = (MAX_CODE+1ULL)/4;
+constexpr uint64_t ONE_HALF = ONE_FOURTH*2;
+constexpr uint64_t THREE_FOURTHS = ONE_FOURTH*3;
 
 uint64_t encoding_bits;
 

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -42,8 +42,8 @@ struct {
 // If write_bits() has been called, call close_wbit() before write_stream()
 
 void open_write(string output_file) {
-    SET_BINARY_MODE(output_file.c_str());
-    zs.file = fopen(output_file.c_str(), "w");
+    //SET_BINARY_MODE(output_file.c_str());
+    zs.file = fopen(output_file.c_str(), "wb");
 }
 
 void write_stream(unsigned char *buf, size_t bytes_to_write)
@@ -92,8 +92,8 @@ void close_write() {
 
 void open_read(string input_file)
 {
-    SET_BINARY_MODE(input_file.c_str());
-    zs.file = fopen(input_file.c_str(), "r");
+    //SET_BINARY_MODE(input_file.c_str());
+    zs.file = fopen(input_file.c_str(), "rb");
     zs.rbytes = 0;
     zs.rbit = -1;
 }

--- a/src/tthresh.hpp
+++ b/src/tthresh.hpp
@@ -16,6 +16,10 @@
 using namespace std;
 using namespace std::chrono;
 
+#ifdef WIN32
+#include <iso646.h> //for 'and' 'or' ...
+#endif
+
 // Size (in bytes) for all I/O buffers
 #define CHUNK (1<<18)
 

--- a/src/tucker.hpp
+++ b/src/tucker.hpp
@@ -12,6 +12,9 @@
 #include "Slice.hpp"
 #include <Eigen/Dense>
 
+#define _USE_MATH_DEFINES
+#include <math.h>
+
 using namespace std;
 using namespace Eigen;
 
@@ -49,7 +52,7 @@ void unproject(MatrixXd& M, MatrixXd& U, MatrixXd& M_proj, Slice slice) {
         }
         MatrixXd convolution = MatrixXd::Zero(slice.get_size(), U.rows()); // convolution*U convolves U along the columns
         #pragma omp parallel for
-        for (uint32_t i = 0; i < slice.get_size(); ++i) {
+        for (int32_t i = 0; i < slice.get_size(); ++i) {
             switch (slice.reduction) {
                 case Downsampling: {
                     convolution(i, slice.points[0]+i*slice.points[2]) = 1; // Delta kernel
@@ -124,7 +127,7 @@ void hosvd_compress(double *data, vector<MatrixXd>& Us, bool verbose)
     // We fold back from matrix into ND tensor
     if (verbose) cout << "\tFold... " << flush << endl;
     #pragma omp parallel for
-    for (uint32_t i = 0; i < s[n-1]; i++)
+    for (int32_t i = 0; i < s[n-1]; i++)
         for (size_t j = 0; j < sprod[n-1]; j++)
             data[i*sprod[n-1] + j] = M_proj(i, j);
 }
@@ -178,7 +181,7 @@ void hosvd_decompress(vector<double>& data, vector<MatrixXd>& Us, bool verbose, 
     data.resize(snewprod[n]);
     data.shrink_to_fit();
     #pragma omp parallel for
-    for (size_t i = 0; i < snewprod[n]; i++)
+    for (ptrdiff_t i = 0; i < snewprod[n]; i++)
         data[i] = M_proj(i/snewprod[n-1], i%snewprod[n-1]);
 }
 


### PR DESCRIPTION
As inspired by https://github.com/rballester/tthresh/issues/1, this adds full compilation support to TThresh and fixes the infinite loop previously discussed in that issue.

- `float128` is only supported on Intel c++ or gcc. If Boost is found, use `boost::multiprecision::cpp_bin_float_quad`, otherwise, fall back to `long double`
- Fixed shifting operations, e.g. `MAX_CODE = (1UL << CODE_VALUE_BITS)-1` to `MAX_CODE = (1ULL << CODE_VALUE_BITS)-1`. With Windows, `1UL` is of type long, which is by default 32bits, not 64bits as `long long`. But we need the full 64 bits here.
  This was also the cause for the infinite loop as mentioned in #1 , in file `compress.hpp`
- use standard "wb" and "rb" instead of "w" and "r" with Unix-specific binary mode macros
- Included iso646.h for `and`, `or` macros
- Changed OpenMP loop variables from unsigned to signed datatypes