### PR TITLE
initialize datamax with  numeric_limits <T>::lowest() instead 

### DIFF
--- a/src/compress.hpp
+++ b/src/compress.hpp
@@ -348,7 +348,7 @@ double *compress(dimensions d, string input_file, string compressed_file, string
 
     // Cast the data to doubles
     double datamin = numeric_limits < double >::max(); // Tensor statistics
-    double datamax = numeric_limits < double >::min();
+    double datamax = numeric_limits < double >::lowest();
     double datanorm = 0;
 
     double *data;

--- a/src/decompress.hpp
+++ b/src/decompress.hpp
@@ -330,7 +330,7 @@ void decompress(dimensions d, string compressed_file, string output_file, double
     double sse = 0;
     double datanorm = 0;
     double datamin = std::numeric_limits < double >::max();
-    double datamax = std::numeric_limits < double >::min();
+    double datamax = std::numeric_limits < double >::lowest();
     double remapped = 0;
     for (size_t i = 0; i < d.snewprod[d.n]; ++i) {
         if (io_type_code == 0) {


### PR DESCRIPTION
initialize datamax with  numeric_limits <T>::lowest() instead  of  numeric_limits <T>::min() for both compress.hpp and decompress.hpp 